### PR TITLE
Add support for custom css

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,17 @@ Cause of moving View.propTypes to ViewPropTypes in React Naitve 0.44 (https://gi
         rel: 'stylesheet'
     }]}
     // change script (have to change source to reload on android)
-    customScript={`document.body.style.background = 'lightyellow';`} />
+    customScript={`document.body.style.background = 'lightyellow';`}
+    // add custom CSS to the page's <head>
+    customStyle={`
+      * {
+        font-family: 'Times New Roman';
+      }
+      p {
+        font-size: 16px;
+      }
+    `}
+  />
 ```
 
 # demo

--- a/autoHeightWebView/index.android.js
+++ b/autoHeightWebView/index.android.js
@@ -31,6 +31,7 @@ export default class AutoHeightWebView extends PureComponent {
     source: WebView.propTypes.source,
     onHeightUpdated: PropTypes.func,
     customScript: PropTypes.string,
+    customStyle: PropTypes.string,
     enableAnimation: PropTypes.bool,
     // if set to false may cause some layout issues (width of container will be than width of screen)
     scalesPageToFit: PropTypes.bool,
@@ -70,9 +71,12 @@ export default class AutoHeightWebView extends PureComponent {
         this
       );
     }
-    const initialScript = props.files
+    let initialScript = props.files
       ? this.appendFilesToHead(props.files, BaseScript)
       : BaseScript;
+    initialScript = props.customStyle
+      ? this.appendStylesToHead(props.customStyle, initialScript)
+      : initialScript;
     this.state = {
       isChangingSource: false,
       height: 0,
@@ -120,6 +124,9 @@ export default class AutoHeightWebView extends PureComponent {
     if (nextProps.files) {
       currentScript = this.appendFilesToHead(nextProps.files, BaseScript);
     }
+    currentScript = nextProps.customStyle
+      ? this.appendStylesToHead(nextProps.customStyle, currentScript)
+      : currentScript;
     this.setState({ script: currentScript });
   }
 
@@ -227,6 +234,19 @@ export default class AutoHeightWebView extends PureComponent {
         script;
     }
     return script;
+  }
+
+  appendStylesToHead(styles, script) {
+    if (!styles) {
+      return script;
+    }
+    return `
+      var styleElement = document.createElement('style');
+      var styleText = document.createTextNode('${styles}');
+      styleElement.appendChild(styleText);
+      document.head.appendChild(styleElement);
+      ${script}
+    `
   }
 
   render() {

--- a/autoHeightWebView/index.android.js
+++ b/autoHeightWebView/index.android.js
@@ -216,24 +216,14 @@ export default class AutoHeightWebView extends PureComponent {
     if (!files) {
       return script;
     }
-    for (let file of files) {
-      script =
-        `
-                var link  = document.createElement('link');
-                link.rel  = '` +
-        file.rel +
-        `';
-                link.type = '` +
-        file.type +
-        `';
-                link.href = '` +
-        file.href +
-        `';
-                document.head.appendChild(link);
-                ` +
-        script;
-    }
-    return script;
+    return files.reduceRight((file, combinedScript) => `
+      var link  = document.createElement('link');
+      link.rel  = '${file.rel}';
+      link.type = '${file.type}';
+      link.href = '${file.href}';
+      document.head.appendChild(link);
+      ${combinedScript}
+    `, script)
   }
 
   appendStylesToHead(styles, script) {

--- a/autoHeightWebView/index.android.js
+++ b/autoHeightWebView/index.android.js
@@ -240,9 +240,11 @@ export default class AutoHeightWebView extends PureComponent {
     if (!styles) {
       return script;
     }
+    // Escape any single quotes or newlines in the CSS with .replace()
+    const escaped = styles.replace(/\'/g, "\\'").replace(/\n/g, '\\n')
     return `
       var styleElement = document.createElement('style');
-      var styleText = document.createTextNode('${styles}');
+      var styleText = document.createTextNode('${escaped}');
       styleElement.appendChild(styleText);
       document.head.appendChild(styleElement);
       ${script}

--- a/autoHeightWebView/index.ios.js
+++ b/autoHeightWebView/index.ios.js
@@ -94,9 +94,11 @@ export default class AutoHeightWebView extends PureComponent {
       if (!styles) {
         return script;
       }
+      // Escape any single quotes or newlines in the CSS with .replace()
+      const escaped = styles.replace(/\'/g, "\\'").replace(/\n/g, '\\n')
       return `
         var styleElement = document.createElement('style');
-        var styleText = document.createTextNode('${styles}');
+        var styleText = document.createTextNode('${escaped}');
         styleElement.appendChild(styleText);
         document.head.appendChild(styleElement);
         ${script}

--- a/autoHeightWebView/index.ios.js
+++ b/autoHeightWebView/index.ios.js
@@ -77,17 +77,14 @@ export default class AutoHeightWebView extends PureComponent {
         if (!files) {
             return script;
         }
-        for (let file of files) {
-            script =
-                `
-                var link  = document.createElement('link');
-                link.rel  = '` + file.rel + `';
-                link.type = '` + file.type + `';
-                link.href = '` + file.href + `';
-                document.head.appendChild(link);
-                `+ script;
-        }
-        return script;
+        return files.reduceRight((file, combinedScript) => `
+          var link  = document.createElement('link');
+          link.rel  = '${file.rel}';
+          link.type = '${file.type}';
+          link.href = '${file.href}';
+          document.head.appendChild(link);
+          ${combinedScript}
+        `, script)
     }
 
     appendStylesToHead(styles, script) {


### PR DESCRIPTION
I used this recently in a project and had to manually insert a stylesheet into the `<head>` of the webview page to influence the styling. I thought it would be cleaner to add it to the library, so here you go.

I wasn't able to write any tests as there weren't any set up, but I tested it locally by putting it into the project I mentioned and making sure it worked.