### PR TITLE
allowBackup=false in AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.dscj.autoheightwebview">
 
-    <application android:allowBackup="true"
+    <application android:allowBackup="false"
                  android:label="@string/app_name"
                  android:supportsRtl="true"
     >

--- a/demo/android/app/src/main/AndroidManifest.xml
+++ b/demo/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
     <application
       android:name=".MainApplication"
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme">


### PR DESCRIPTION
A [recent pull in React Native](https://github.com/facebook/react-native/pull/17596) changed the AndroidManifest templates to use allowBackup=false.  When upgrading using 'react-native-git-upgrade' for example, the project's allowBackup will be automatically set to false.  You will then get the following error with this package:

```
Execution failed for task ':app:processReleaseManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:11:7-34
  	is also present at [chatConsoleMobile:react-native-autoheight-webview:unspecified] AndroidManifest.xml:12:9-35 value=(true).
```
