### PR TITLE
Adding AutoWidth capability 

### DIFF
--- a/autoHeightWebView/common.js
+++ b/autoHeightWebView/common.js
@@ -5,7 +5,7 @@ function appendFilesToHead(files, script) {
     return script;
   }
   return files.reduceRight((file, combinedScript) => {
-    const { rel, type, href } = file;
+      const { rel, type, href } = file;
     return `
             var link  = document.createElement('link');
             link.rel  = '${rel}';
@@ -17,12 +17,29 @@ function appendFilesToHead(files, script) {
   }, script);
 }
 
-function appendStylesToHead(styles, script) {
-  if (!styles) {
-    return script;
-  }
+function appendStylesToHead(styles, script, shouldResizeWidth) {
+    var bodyStyle;
+    if (shouldResizeWidth) {
+        bodyStyle = `
+            body {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }`;
+    }
+    else {
+        bodyStyle = '';
+    }
+    
+    if (!styles) {
+        styles = bodyStyle;
+    }
+    else {
+        styles += bodyStyle;
+    }
   // Escape any single quotes or newlines in the CSS with .replace()
-  const escaped = styles.replace(/\'/g, "\\'").replace(/\n/g, '\\n');
+    const escaped = styles.replace(/\'/g, "\\'").replace(/\n/g, '\\n');
+    
   return `
           var styleElement = document.createElement('style');
           var styleText = document.createTextNode('${escaped}');
@@ -33,15 +50,25 @@ function appendStylesToHead(styles, script) {
 }
 
 function getScript(props, baseScript, iframeBaseScript) {
-  const { hasIframe, files, customStyle } = props;
+    const { hasIframe, files, customStyle, shouldResizeWidth } = props;
   let script = hasIframe ? iframeBaseScript : baseScript;
   script = files ? appendFilesToHead(files, baseScript) : baseScript;
-  script = customStyle ? appendStylesToHead(customStyle, script) : script;
+    script = appendStylesToHead(customStyle, script, shouldResizeWidth);
   return script;
 }
 
 function onHeightUpdated(height, props) {
   props.onHeightUpdated && props.onHeightUpdated(height);
+}
+
+function onWidthUpdated(width, props) {
+    props.onWidthUpdated && props.onWidthUpdated(width);
+}
+
+function onHeightWidthUpdated(height, width, props) {
+    onHeightUpdated(height, props);
+    onWidthUpdated(width, props);
+    props.onHeightWidthUpdated && props.onHeightWidthUpdated(height, width);
 }
 
 const domMutationObserveScript = 
@@ -54,4 +81,4 @@ observer.observe(document, {
 });
 `;
 
-export { getScript, onHeightUpdated, domMutationObserveScript };
+export { getScript, onHeightUpdated, onWidthUpdated, onHeightWidthUpdated, domMutationObserveScript };


### PR DESCRIPTION
Thanks for this great library! It helped me a great deal.

I had to use `<AutoHeightWebView />` inline so I've changed the code, adding an auto-width capability to `<AutoHeightWebView />` .
Now `<AutoHeightWebView />` accepts `shouldResizeWidth` as a `prop` that defaults to `false`.

Firing Events:
`onHeightUpdated` fires as well as `onWidthUpdated` and `onHeightWidthUpdated`.
I didn't change the firing logic, meaning that `onHeightWidthUpdated` fires (instead of `onHeightUpdated`) when a change of size occurs (see 'Considerations#2')  and in turn fires both `onHeightUpdated` and `onWidthUpdated`.

```
<AutoHeightWebView
          shouldResizeWidth={true}
          onHeightUpdated={(height) => console.log('height updated', height)}
          onWidthUpdated={(width) => console.log('width updated', width)}
          onHeightWidthUpdated={(height, width) => this.setState({ height, width })} />
```
---
Considerations:
1. `<WebView>` width resizing occurs by applying `flex` styling on `document.body`, check out `appendStylesToHead()` in `common.js`. (Hope this doesn't cause bugs in some use cases).
2. In the `onMessage` method in `index.android.js` I changed the main logic to
 `if (height && height !== this.state.height && width && width !== this.state.width) `.
In the `handleNavigationStateChange` method in `index.ios.js` I wasn't sure how it would behave so I left it as before: `if (height && height !== this.state.height) `.
I don't think this change causes much of a difference , just thinking about exceptions.
Maybe best to use the original logic as long as the firing logic (described above in 'Firing Events') stays the same.

-----
**I've tested it on android and it works!
Couldn't test on iOS (for now), but I did my best to adjust the code.**
