### PR TITLE
add missing param in callback

### DIFF
--- a/autoHeightWebView/index.ios.js
+++ b/autoHeightWebView/index.ios.js
@@ -128,7 +128,7 @@ export default class AutoHeightWebView extends PureComponent {
         width
       });
     }
-    onNavigationStateChange && onNavigationStateChange();
+    onNavigationStateChange && onNavigationStateChange(navState);
   };
 
   stopLoading() {


### PR DESCRIPTION
onNavigationStateChange will not return navState in normal case.

Yet the navState is quite useful if we want to implement feature like following:
https://stackoverflow.com/questions/35531679/react-native-open-links-in-browser