### PR TITLE
Updates component to use ResizeObserver if available. Added fluid width option

### DIFF
--- a/autoHeightWebView/index.js
+++ b/autoHeightWebView/index.js
@@ -56,6 +56,15 @@ const AutoHeightWebView = React.memo(
     const { currentSource, script } = reduceData(props);
 
     const { width, height } = size;
+
+    const dimentions = {
+      height
+    };
+  
+    if (!props.fluidWidth) {
+      dimentions.width = width;
+    }
+    
     useEffect(
       () =>
         onSizeUpdated &&
@@ -73,10 +82,7 @@ const AutoHeightWebView = React.memo(
         onMessage={handleMessage}
         style={[
           styles.webView,
-          {
-            width,
-            height
-          },
+          dimentions,
           style
         ]}
         injectedJavaScript={script}
@@ -102,6 +108,7 @@ AutoHeightWebView.propTypes = {
   customScript: PropTypes.string,
   customStyle: PropTypes.string,
   zoomable: PropTypes.bool,
+  fluidWidth: PropTypes.bool,
   // webview props
   originWhitelist: PropTypes.arrayOf(PropTypes.string),
   onMessage: PropTypes.func,

--- a/autoHeightWebView/utils.js
+++ b/autoHeightWebView/utils.js
@@ -1,31 +1,39 @@
 'use strict';
 
-import { Dimensions, Platform } from 'react-native';
+import { Dimensions } from 'react-native';
 
-const domMutationObserveScript = `
-var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
-var observer = new MutationObserver(updateSize);
-observer.observe(document, {
-    subtree: true,
-    attributes: true
-});
-`;
-
-const updateSizeWithMessage = element =>
-  `
-  var updateSizeInterval = null;
-  var height = 0;
-  function updateSize(event) {
-    if (!window.hasOwnProperty('ReactNativeWebView') || !window.ReactNativeWebView.hasOwnProperty('postMessage')) {
-      !updateSizeInterval && (updateSizeInterval = setInterval(updateSize, 200));
-      return;
-    }
-    clearInterval(updateSizeInterval)
-    height = ${element}.offsetHeight || window.innerHeight;
-    width = ${element}.offsetWidth || window.innerWidth;
-    window.ReactNativeWebView.postMessage(JSON.stringify({ width: width, height: height }));
+function updateSize() {
+  if (!window.hasOwnProperty('ReactNativeWebView') || !window.ReactNativeWebView.hasOwnProperty('postMessage')) {
+    setTimeout(updateSize, 200);
+    return;
   }
-  `;
+
+  // we use body dimentions because window is stretched to size of WebView
+  const height = document.body.offsetHeight;
+  const width = document.body.offsetWidth;
+  
+  window.ReactNativeWebView.postMessage(
+    JSON.stringify({ 
+      width, height
+    })
+  );
+}
+
+function addResizeObserverWithFallback () {
+  const isResizeObserverSupported = 'ResizeObserver' in window;
+
+  if (isResizeObserverSupported) {
+    const observer = new ResizeObserver(updateSize);
+
+    observer.observe(document.body);
+  } else {
+    // if old webview and doesn't support ResizeObserver
+    // use old behaviour, there still can be some additional spacing
+    // but at least nothing will be cropped
+    window.addEventListener('load', updateSize);
+    window.addEventListener('resize', updateSize);
+  }
+}
 
 // add viewport setting to meta for WKWebView
 const makeScalePageToFit = zoomable => `
@@ -33,28 +41,18 @@ var meta = document.createElement('meta');
 meta.setAttribute('name', 'viewport'); 
 meta.setAttribute('content', 'width=device-width, user-scalable=${
   zoomable ? 'yes' : 'no'
-}'); document.getElementsByTagName('head')[0].appendChild(meta);
+}');
+document.getElementsByTagName('head')[0].appendChild(meta);
 `;
 
-const getBaseScript = ({ style, zoomable }) =>
-  `
+const getBaseScript = ({zoomable}) => `
   ;
-  if (!document.getElementById("rnahw-wrapper")) {
-    var wrapper = document.createElement('div');
-    wrapper.id = 'rnahw-wrapper';
-    while (document.body.firstChild instanceof Node) {
-      wrapper.appendChild(document.body.firstChild);
-    }
-    document.body.appendChild(wrapper);
-  }
-  var width = ${getWidth(style)};
-  ${updateSizeWithMessage('wrapper')}
-  window.addEventListener('load', updateSize);
-  window.addEventListener('resize', updateSize);
-  ${domMutationObserveScript}
-  ${Platform.OS === 'ios' ? makeScalePageToFit(zoomable) : ''}
+  ${updateSize.toString()}
+  ${addResizeObserverWithFallback.toString()}
+  addResizeObserverWithFallback();
   updateSize();
-  `;
+  ${makeScalePageToFit(zoomable)}
+`;
 
 const appendFilesToHead = ({ files, script }) =>
   files.reduceRight((combinedScript, file) => {
@@ -83,17 +81,20 @@ const appendStylesToHead = ({ style, script }) => {
   // Escape any single quotes or newlines in the CSS with .replace()
   const escaped = currentStyles.replace(/\'/g, "\\'").replace(/\n/g, '\\n');
   return `
-          var styleElement = document.createElement('style');
-          styleElement.innerHTML = '${escaped}';
-          document.head.appendChild(styleElement);
-          ${script}
-        `;
+    var styleElement = document.createElement('style');
+    styleElement.innerHTML = '${escaped}';
+    document.head.appendChild(styleElement);
+    ${script}
+  `;
 };
 
+// we use IIFE to create local variables scope
 const getInjectedSource = ({ html, script }) => `
 ${html}
 <script>
+(() => {
 ${script}
+})();
 </script>
 `;
 

--- a/autoHeightWebView/utils.js
+++ b/autoHeightWebView/utils.js
@@ -2,7 +2,7 @@
 
 import { Dimensions } from 'react-native';
 
-function updateSize() {
+const updateSizeFn = `function updateSize() {
   if (!window.hasOwnProperty('ReactNativeWebView') || !window.ReactNativeWebView.hasOwnProperty('postMessage')) {
     setTimeout(updateSize, 200);
     return;
@@ -17,9 +17,9 @@ function updateSize() {
       width, height
     })
   );
-}
+}`;
 
-function addResizeObserverWithFallback () {
+const addResizeObserverWithFallbackFn = `function addResizeObserverWithFallback () {
   const isResizeObserverSupported = 'ResizeObserver' in window;
 
   if (isResizeObserverSupported) {
@@ -33,7 +33,7 @@ function addResizeObserverWithFallback () {
     window.addEventListener('load', updateSize);
     window.addEventListener('resize', updateSize);
   }
-}
+}`;
 
 // add viewport setting to meta for WKWebView
 const makeScalePageToFit = zoomable => `
@@ -47,8 +47,8 @@ document.getElementsByTagName('head')[0].appendChild(meta);
 
 const getBaseScript = ({zoomable}) => `
   ;
-  ${updateSize.toString()}
-  ${addResizeObserverWithFallback.toString()}
+  ${updateSizeFn}
+  ${addResizeObserverWithFallbackFn}
   addResizeObserverWithFallback();
   updateSize();
   ${makeScalePageToFit(zoomable)}


### PR DESCRIPTION
Hello, 

First of all I'd like to thank you for this component, it made my live so much easier, but I've found some issues and would like to help improve it's behaviour.

I've noticed issue with webview sizes when HTML has twitter embeds (I can provide test HTML to show you the problem), and size of WebView ends up being larger than is should be.

I would like to propose update for size change detection strategy in favor of ResizeObserver, with fallback to regular window.onresize for WebView implementations that don't support it.

Also I propose fluidWidth option, which would allow parent element control width of WebView.

