### PR TITLE
Use React.createElement instead of JSX

### DIFF
--- a/autoHeightWebView/index.js
+++ b/autoHeightWebView/index.js
@@ -66,24 +66,22 @@ const AutoHeightWebView = React.memo(
       [width, height, onSizeUpdated],
     );
 
-    return (
-      <WebView
-        {...props}
-        ref={ref}
-        onMessage={handleMessage}
-        style={[
-          styles.webView,
-          {
-            width,
-            height,
-          },
-          style,
-        ]}
-        injectedJavaScript={script}
-        source={currentSource}
-        scrollEnabled={currentScrollEnabled}
-      />
-    );
+    return React.createElement(WebView, {
+      ...props,
+      ref,
+      onMessage: handleMessage,
+      style: [
+        styles.webView,
+        {
+          width,
+          height,
+        },
+        style,
+      ],
+      injectedJavaScript: script,
+      source: currentSource,
+      scrollEnabled: currentScrollEnabled
+    });
   }),
   (prevProps, nextProps) => !shouldUpdate({prevProps, nextProps}),
 );


### PR DESCRIPTION
While raw react-native will successfully load this library, some environments might not have sufficient transpilation rules for packages imported in node_modules, resulting in parse errors (can't parse JSX). This fix will make this package more universal and eliminate the need of adding targetted transpilation rule to babel.config.js.