### PR TITLE
Fixed wrong imported PropTypes

### DIFF
--- a/autoHeightWebView/index.js
+++ b/autoHeightWebView/index.js
@@ -1,8 +1,10 @@
 import React, {useState, useEffect, forwardRef} from 'react';
 
-import {StyleSheet, Platform, ViewPropTypes} from 'react-native';
+import {StyleSheet, Platform} from 'react-native';
 
-import PropTypes from 'deprecated-react-native-prop-types';
+import {ViewPropTypes} from 'deprecated-react-native-prop-types';
+
+import PropTypes from 'prop-types';
 
 import {WebView} from 'react-native-webview';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-autoheight-webview",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-autoheight-webview",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "An auto height webview for React Native, even auto width for inline html",
   "main": "autoHeightWebView",
   "types": "index.d.ts",


### PR DESCRIPTION
Should be 
**import {ViewPropTypes} from 'deprecated-react-native-prop-types'**
instead of
**import PropTypes from 'deprecated-react-native-prop-types'**
