### PR TITLE
Fix: undefined wrapper when already initialized

### DIFF
--- a/autoHeightWebView/utils.js
+++ b/autoHeightWebView/utils.js
@@ -128,8 +128,9 @@ const getBaseScript = ({
 }) =>
   `
   ;
-  if (!document.getElementById("rnahw-wrapper")) {
-    var wrapper = document.createElement('div');
+  var wrapper = document.getElementById("rnahw-wrapper");
+  if (!wrapper) {
+    wrapper = document.createElement('div');
     wrapper.id = 'rnahw-wrapper';
     while (document.body.firstChild instanceof Node) {
       wrapper.appendChild(document.body.firstChild);


### PR DESCRIPTION
This fixes #243 by ensuring wrapper is always set not just when the wrapper div is not present.