### PR TITLE
Updated deprecated-react-native-prop-types to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-native-webview": ">= 10.9.0"
   },
   "dependencies": {
-    "deprecated-react-native-prop-types": "^2.3.0",
+    "deprecated-react-native-prop-types": "^4.0.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
deprecated-react-native-prop-types is now up to v4 - https://github.com/facebook/react-native-deprecated-modules/blob/main/deprecated-react-native-prop-types/CHANGELOG.md

This PR upgrades the dependency from ^2.3.0.